### PR TITLE
Remove vertical margin on <li> elements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "files.associations": {
+    "*.scss": "tailwindcss",
     "*.mdx": "markdown"
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,17 @@ module.exports = {
         primary: [fontPrimary, fontPrimaryType],
         secondary: [fontSecondary, fontSecondaryType],
       },
+      typography: {
+        DEFAULT: {
+          css: {
+            // Troop 150: Items felt too spaced out vertically
+            li: {
+              "margin-top": 0,
+              "margin-bottom": 0,
+            }
+          }
+        }
+      }
     },
   },
   plugins: [


### PR DESCRIPTION
This overrides the default margin from tailwindcss-typography of 0.5em,
which felt too large.